### PR TITLE
Make debug arg optional

### DIFF
--- a/download-engine.sh
+++ b/download-engine.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eo pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 


### PR DESCRIPTION
Without this change `./download-engine.sh` gives the error:

```
./download-engine.sh: line 11: $1: unbound variable
```