### PR TITLE
Support building for osx

### DIFF
--- a/build-engine.sh
+++ b/build-engine.sh
@@ -15,7 +15,6 @@ cat << EOF > "$mozconfig"
 ac_add_options --enable-project=js
 ac_add_options --enable-application=js
 ac_add_options --target=wasm32-unknown-wasi
-ac_add_options --disable-stdcxx-compat
 ac_add_options --without-system-zlib
 ac_add_options --without-intl-api
 ac_add_options --disable-jit
@@ -29,6 +28,22 @@ ac_add_options --enable-js-streams
 ac_add_options --prefix=${working_dir}/${objdir}/dist
 mk_add_options MOZ_OBJDIR=${working_dir}/${objdir}
 EOF
+
+target="$(uname)"
+case "$target" in
+  Linux)
+    echo "ac_add_options --disable-stdcxx-compat" >> "$mozconfig"
+    ;;
+
+  Darwin)
+    echo "ac_add_options --host=aarch64-apple-darwin" >> "$mozconfig"
+    ;;
+
+  *)
+    echo "Unsupported build target: $target"
+    exit 1
+    ;;
+esac
 
 case "$mode" in
   release)


### PR DESCRIPTION
This PR fixes some problems when running the `build-engine.sh` script on osx.

I started working on getting an osx debug build that we could cache along with other artifacts on [this branch](https://github.com/fastly/spidermonkey-wasi-embedding/tree/trevor/osx-build-ci), but ran into some issues with [homebrew being required](https://github.com/fastly/spidermonkey-wasi-embedding/actions/runs/3698317793/jobs/6264377216). I split this PR off of that work because it's useful for unblocking building a debug version of spidermonkey on osx, but the process for using it there is still more manual.