### PR TITLE
Build with -O3.

### DIFF
--- a/build-engine.sh
+++ b/build-engine.sh
@@ -23,7 +23,7 @@ ac_add_options --disable-shared-memory
 ac_add_options --disable-tests
 ac_add_options --disable-clang-plugin
 ac_add_options --enable-jitspew
-ac_add_options --enable-optimize
+ac_add_options --enable-optimize=-O3
 ac_add_options --enable-js-streams
 ac_add_options --enable-portable-baseline-interp
 ac_add_options --prefix=${working_dir}/${objdir}/dist

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -23,7 +23,7 @@ ac_add_options --disable-shared-memory
 ac_add_options --disable-tests
 ac_add_options --disable-clang-plugin
 ac_add_options --enable-jitspew
-ac_add_options --enable-optimize
+ac_add_options --enable-optimize=-O3
 ac_add_options --enable-js-streams
 ac_add_options --enable-portable-baseline-interp
 ac_add_options --prefix=${working_dir}/${objdir}/dist


### PR DESCRIPTION
This is needed for PBL to build properly (with expected performance characteristics): otherwise, inlining of various parts of the interpreter loop is quite suboptimal, and "always inline" directives are not followed.